### PR TITLE
Add remote debug option

### DIFF
--- a/bin/start.js
+++ b/bin/start.js
@@ -43,6 +43,7 @@ try {
 }
 
 nodemon({
+  nodeArgs: (process.env.REMOTE_DEBUG) ? ['--debug'] : [],
   script: __dirname + '/../server.js',
   args: [path  + '/' + mainScriptFile, skillPackageConf.name],
   watch: [


### PR DESCRIPTION
I add remote debug option, for #6 .
You can pass remote debug option in environemt and start alexa-skill-test in remote debug mode, as follows.
```
REMOTE_DEBUG alexa-skill-test
```