### PR TITLE
Modify nodemon environment

### DIFF
--- a/bin/start.js
+++ b/bin/start.js
@@ -52,6 +52,6 @@ nodemon({
     path + '/'
   ],
   env: {
-    DEBUG: (process.env.DEBUG) ? process.env.DEBUG : 'skill'
+    'DEBUG': (process.env.DEBUG) ? process.env.DEBUG : 'skill'
   }
 });


### PR DESCRIPTION
A skill in alexa-skill-test has no `process.env`.
Because `env` object is not generated by typo, as pointed out in this pull request.
