### PR TITLE
Error and exit when skill package.json doesn't have a name property

### DIFF
--- a/bin/start.js
+++ b/bin/start.js
@@ -27,6 +27,11 @@ try {
   process.exit(1);
 }
 
+if (typeof skillPackageConf.name !== 'string') {
+  console.error('Package.json requires a name property.'.red);
+  process.exit(1);
+}
+
 if (!skillPackageConf.main) {
   console.error('Main script file not found.'.red);
   process.exit(1);


### PR DESCRIPTION
First off, thanks for your project. It made iterating locally much easier ✌️ 

It seems pretty silly that my `package.json` didn't have a name property. I was following a workshop from amazon on alexa skills and ended up with my `package.json` not have a `name` property 😢.

This PR adds a helpful hint in case the name property is not a string. Just in case someone else comes along and gets a cryptic throw like this from `nodemon`.
```
Uncaught exception: TypeError: Cannot read property 'indexOf' of undefined
TypeError: Cannot read property 'indexOf' of undefined
    at /Users/chadcarbert/projects/alexa-skill-test/node_modules/nodemon/lib/utils/index.js:69:16
    at Array.map (native)
    at Object.stringify (/Users/chadcarbert/projects/alexa-skill-test/node_modules/nodemon/lib/utils/index.js:66:12)
    at /Users/chadcarbert/projects/alexa-skill-test/node_modules/nodemon/lib/config/index.js:69:21
    at normaliseRules (/Users/chadcarbert/projects/alexa-skill-test/node_modules/nodemon/lib/config/load.js:146:3)
    at ready (/Users/chadcarbert/projects/alexa-skill-test/node_modules/nodemon/lib/config/load.js:87:9)
    at /Users/chadcarbert/projects/alexa-skill-test/node_modules/nodemon/lib/config/load.js:104:7
    at callback (/Users/chadcarbert/projects/alexa-skill-test/node_modules/nodemon/lib/config/load.js:164:5)
    at /Users/chadcarbert/projects/alexa-skill-test/node_modules/nodemon/lib/config/load.js:211:5
    at callback (/Users/chadcarbert/projects/alexa-skill-test/node_modules/nodemon/lib/config/load.js:164:5)
/Users/chadcarbert/projects/hammy/node_modules/alexa-sdk/lib/alexa.js:301
    throw err;
    ^

TypeError: Cannot read property 'indexOf' of undefined
    at /Users/chadcarbert/projects/alexa-skill-test/node_modules/nodemon/lib/utils/index.js:69:16
    at Array.map (native)
    at Object.stringify (/Users/chadcarbert/projects/alexa-skill-test/node_modules/nodemon/lib/utils/index.js:66:12)
    at /Users/chadcarbert/projects/alexa-skill-test/node_modules/nodemon/lib/config/index.js:69:21
    at normaliseRules (/Users/chadcarbert/projects/alexa-skill-test/node_modules/nodemon/lib/config/load.js:146:3)
    at ready (/Users/chadcarbert/projects/alexa-skill-test/node_modules/nodemon/lib/config/load.js:87:9)
    at /Users/chadcarbert/projects/alexa-skill-test/node_modules/nodemon/lib/config/load.js:104:7
    at callback (/Users/chadcarbert/projects/alexa-skill-test/node_modules/nodemon/lib/config/load.js:164:5)
    at /Users/chadcarbert/projects/alexa-skill-test/node_modules/nodemon/lib/config/load.js:211:5
    at callback (/Users/chadcarbert/projects/alexa-skill-test/node_modules/nodemon/lib/config/load.js:164:5)
```
